### PR TITLE
Add support for volumesFrom in ECS Task Definition

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,1 +1,2 @@
 Micah  Hausler (micah.hausler@ambition.com)
+Samuel Karp (skarp@amazon.com)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM dockerfile/python:latest
+
+COPY . /container-transform
+
+RUN \
+	cd /container-transform && \
+	python /container-transform/setup.py install
+
+WORKDIR /data
+CMD ["container-transform", "-v"]

--- a/container_transform/converter.py
+++ b/container_transform/converter.py
@@ -82,7 +82,8 @@ class Converter(object):
                     )
                 )
 
-            if container.get(input_name) and hasattr(self._input_class, 'ingest_{}'.format(parameter)) and \
+            if container.get(input_name) and \
+                    hasattr(self._input_class, 'ingest_{}'.format(parameter)) and \
                     output_name and hasattr(self._output_class, 'emit_{}'.format(parameter)):
                 # call transform_{}
                 ingest_func = getattr(self._input_class, 'ingest_{}'.format(parameter))

--- a/container_transform/ecs.py
+++ b/container_transform/ecs.py
@@ -132,3 +132,11 @@ class ECSTransformer(BaseTransformer):
     @staticmethod
     def emit_entrypoint(entrypoint):
         return entrypoint.split()
+
+    @staticmethod
+    def ingest_volumes_from(volumes_from):
+        return [vol['sourceContainer'] for vol in volumes_from]
+
+    @staticmethod
+    def emit_volumes_from(volumes_from):
+        return [{'sourceContainer': vol} for vol in volumes_from]

--- a/container_transform/fig.py
+++ b/container_transform/fig.py
@@ -199,3 +199,11 @@ class FigTransformer(BaseTransformer):
     @staticmethod
     def emit_entrypoint(entrypoint):
         return entrypoint
+
+    @staticmethod
+    def ingest_volumes_from(volumes_from):
+        return volumes_from
+
+    @staticmethod
+    def emit_volumes_from(volumes_from):
+        return volumes_from

--- a/container_transform/schema.py
+++ b/container_transform/schema.py
@@ -112,7 +112,7 @@ ARG_MAP = {
     },
     'volumes_from': {
         TransformationTypes.ECS.value: {
-            'name': None,
+            'name': 'volumesFrom',
             'required': False
         },
         TransformationTypes.FIG.value: {

--- a/container_transform/tests/fig.yml
+++ b/container_transform/tests/fig.yml
@@ -48,3 +48,9 @@ web2:
   mem_limit: 1024b
   entrypoint: uwsgi
   command: --json uwsgi.json
+logs:
+  image: me/mylogs
+  mem_limit: 1024b
+  volumes_from:
+  - web
+  - web2

--- a/container_transform/tests/task.json
+++ b/container_transform/tests/task.json
@@ -22,6 +22,22 @@
     },
     {
         "cpu": 200,
+        "essential": true,
+        "name": "logs",
+        "memory": 4,
+        "image": "me/mylogs",
+        "volumesFrom": [
+            {
+                "sourceContainer": "web",
+                "readOnly": true
+            },
+            {
+                "sourceContainer": "web2"
+            }
+        ]
+    },
+    {
+        "cpu": 200,
         "links": [
             "db",
             "redis"

--- a/container_transform/transformer.py
+++ b/container_transform/transformer.py
@@ -19,6 +19,7 @@ SCHEMA = {
     'environment': dict,  # A simple key: value dictionary
     'entrypoint': str,  # An unsplit string
     'command': str,  # An unsplit string
+    'volumes_from': list,  # A list of containers, ignoring read_only
 }
 
 
@@ -181,4 +182,14 @@ class BaseTransformer(six.with_metaclass(ABCMeta), object):
     @staticmethod
     @abstractmethod
     def emit_entrypoint(entrypoint):
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def ingest_volumes_from(volumes_from):
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def emit_volumes_from(volumes_from):
         raise NotImplementedError

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 # import multiprocessing to avoid this bug (http://bugs.python.org/issue15881#msg170215)
 import multiprocessing
-assert multiprocessing
 import re
 from setuptools import setup, find_packages
+assert multiprocessing
 
 
 def get_version():


### PR DESCRIPTION
This commit adds support for [volumesFrom](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html#using_data_volumes) in ECS Task Definitions.  Note that this change does not yet add support for the `volumes` structure in a Task Definition, which is required to use defined, persistent host volumes or empty, nonpersistent host volumes.